### PR TITLE
fix(esbuild): Prevent invalid webpack configuration

### DIFF
--- a/src/optimisations/esbuild.ts
+++ b/src/optimisations/esbuild.ts
@@ -51,8 +51,13 @@ export default (args: OptimisationArgs) => {
       rule.use.splice(babelLoaderIndex, 1, esbuildLoader)
       // @ts-ignore
       const tsLoaderIndex = rule.use.findIndex((use: RuleSetUseItem) => use.loader.includes('ts-loader'))
-      rule.use.splice(tsLoaderIndex, 1)
-      logger.debug(`TS compilation: swapped out ts-loader at index ${tsLoaderIndex} for esbuild`)
+      
+      // remove ts-loader only if present
+      if (tsLoaderIndex !== -1) {
+          rule.use.splice(tsLoaderIndex, 1)
+          logger.debug(`TS compilation: swapped out ts-loader at index ${tsLoaderIndex} for esbuild`)
+      }
+      
       return rule
     })
   }


### PR DESCRIPTION
If no ts-loader exists and still splice is called, the webpack configuration is faulty. That's the case when findIndex returns -1 (meaning: element not found; no index given). splice can handle negative numbers and interprets these as the n-th last element. In order to fix this we just have to check if findIndex returns a number except -1.